### PR TITLE
Configure flake8 to ignore unused imports in inits

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -4,6 +4,6 @@ scanner:
 
 flake8:
   max-line-length: 120  # Default is 79 in PEP 8
-  ignore: []
+  ignore: [ ]
 
 no_blank_comment: False  # Every PR will have its own pep8speaks stats

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,7 @@ project_urls =
 package_dir =
     meta_automl = meta_automl
 install_requires = file: requirements.txt
+
+[flake8]
+per-file-ignores =
+    */__init__.py:F401


### PR DESCRIPTION
Added a configuration in setup.cfg for flake8 to ignore F401 in `*/__init__.py` files