### PR TITLE
Move flake8 settings to setup.cfg

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,8 +2,4 @@ scanner:
   diff_only: False  # The entire file touched by the PR will be scanned for errors
   linter: flake8
 
-flake8:
-  max-line-length: 120  # Default is 79 in PEP 8
-  ignore: [ ]
-
 no_blank_comment: False  # Every PR will have its own pep8speaks stats

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,4 @@ install_requires = file: requirements.txt
 [flake8]
 per-file-ignores =
     */__init__.py:F401
+max-line-length = 120


### PR DESCRIPTION
It is needed, since pep8speaks ignores setup.cfg file while the section flake8 is duplicated in both it and .pep8speaks.yml